### PR TITLE
configフォーマット更新

### DIFF
--- a/client/src/config.rs
+++ b/client/src/config.rs
@@ -1,19 +1,32 @@
-use std::collections::HashMap;
+use std::{collections::HashMap, process::exit};
 
 use serde::{Serialize, Deserialize};
 
 #[derive(Default, Debug, Serialize, Deserialize)]
 pub(crate) struct Config {
-    servers: HashMap<String, url::Url>,
-    token: Option<String>
+    pub(crate) default: DefaultConfig,
+    pub(crate) servers: HashMap<String, ServerConfig>,
+}
+
+#[derive(Default, Debug, Serialize, Deserialize)]
+pub(crate) struct DefaultConfig {
+    pub(crate) server: String,
+}
+
+#[derive(Debug, Serialize, Deserialize)]
+pub(crate) struct ServerConfig {
+    pub(crate) url: url::Url,
+    pub(crate) token: String,
 }
 
 impl Config {
     pub(crate) fn load() -> Self {
-        confy::load("freight-train", "config").unwrap()
+        confy::load("freight-train", "config").unwrap_or_else(|error| {
+            eprintln!("{:?}", error);
+            exit(1);
+        })
     }
 
-    #[allow(dead_code)] // 使用時はこのアノテーションを取り除くこと
     pub(crate) fn store(&self) {
         confy::store("freight-train", "config", self).unwrap_or_else(|error| eprintln!("{error}"))
     }

--- a/client/src/config.rs
+++ b/client/src/config.rs
@@ -10,7 +10,7 @@ pub(crate) struct Config {
 
 #[derive(Default, Debug, Serialize, Deserialize)]
 pub(crate) struct DefaultConfig {
-    pub(crate) server: String,
+    pub(crate) server: Option<String>,
 }
 
 #[derive(Debug, Serialize, Deserialize)]

--- a/client/src/config.rs
+++ b/client/src/config.rs
@@ -16,7 +16,7 @@ pub(crate) struct DefaultConfig {
 #[derive(Debug, Serialize, Deserialize)]
 pub(crate) struct ServerConfig {
     pub(crate) url: url::Url,
-    pub(crate) token: String,
+    pub(crate) token: Option<String>,
 }
 
 impl Config {


### PR DESCRIPTION
# configフォーマット更新
https://www.notion.so/naotiki/17d61943b2b18078b291fa1aa92349af
- より厳密に型を定義するため，複数の構造体に分割しました．
- configの読み込み失敗時に`panic`するのはやっぱりマズい気がしたのでエラー内容だけ吐いてコード1で終了するようにしました．（今後`anyhow`使っていきたい）
- `store()`の未使用はあえてwarning出すべきだと思ったのでアノテーション外しました．